### PR TITLE
Night tasks should now be executed in a FIFO order

### DIFF
--- a/routine_behaviours/scripts/patroller_routine_node.py
+++ b/routine_behaviours/scripts/patroller_routine_node.py
@@ -14,22 +14,22 @@ if __name__ == '__main__':
     # start and end times -- all times should be in local timezone
     localtz = tzlocal()
     start = time(8,30, tzinfo=localtz)
-    end = time(0,37, tzinfo=localtz)
+    end = time(17,00, tzinfo=localtz)
 
     # how long to stand idle before doing something
     idle_duration=rospy.Duration(20)
 
-    # how long you think it will take to do a complete tour. overestimate is better than under
-    # tour_duration_estimate = rospy.Duration(60 * 40 * 2)
-
-# for dummy testing
-    tour_duration_estimate = rospy.Duration(60)
-
-    routine = PatrolRoutine(daily_start=start, daily_end=end, 
-        idle_duration=idle_duration, tour_duration_estimate=tour_duration_estimate)    
-    
-    # set tasks and start execution
+    routine = PatrolRoutine(daily_start=start, daily_end=end, idle_duration=idle_duration)    
+     
+    # create a routine to patrol all points in the environment
+    # 
+    # if you want to patrol different points use create_patrol_routine instead of
+    # create_routine and you can use the all_waypoints and all_waypoints_except 
+    # methods to configure locations to patrol
+    # 
     routine.create_routine()
+ 
+    # set tasks and start execution
     routine.start_routine()
-    
+
     rospy.spin()

--- a/routine_behaviours/src/routine_behaviours/patrol_routine.py
+++ b/routine_behaviours/src/routine_behaviours/patrol_routine.py
@@ -22,11 +22,10 @@ import random
 class PatrolRoutine(RobotRoutine):
     """ Creates a routine which simply visits nodes. """
 
-    def __init__(self, daily_start, daily_end, tour_duration_estimate=None, idle_duration=rospy.Duration(5), charging_point = 'ChargingPoint'):
+    def __init__(self, daily_start, daily_end, idle_duration=rospy.Duration(5), charging_point = 'ChargingPoint'):
         # super(PatrolRoutine, self).__init__(daily_start, daily_end)        
         RobotRoutine.__init__(self, daily_start, daily_end, idle_duration=idle_duration, charging_point=charging_point)
-        self.node_names = set()
-        self.tour_duration_estimate = tour_duration_estimate
+        self.node_names = set()        
         rospy.Subscriber('topological_map', TopologicalMap, self.map_callback)
         self.random_nodes = []
 
@@ -69,8 +68,7 @@ class PatrolRoutine(RobotRoutine):
             waypoints = self.get_nodes()
 
         if not repeat_delta:
-            # ignoring this now
-            # if not self.tour_duration_estimate:
+            # ignoring this now            
             single_node_estimate = self.max_single_trip_time(waypoints).to_sec()
             tour_duration_estimate = single_node_estimate * (len(waypoints)-1) * 2
             repeat_delta = timedelta(seconds=tour_duration_estimate)

--- a/routine_behaviours/src/routine_behaviours/robot_routine.py
+++ b/routine_behaviours/src/routine_behaviours/robot_routine.py
@@ -267,7 +267,6 @@ class RobotRoutine(object):
             instantiated_night_tasks.append(night_task)
             now = now + delta
 
-
         self.add_tasks(instantiated_night_tasks)
         self.sent_night_tasks = True
 

--- a/routine_behaviours/src/routine_behaviours/robot_routine.py
+++ b/routine_behaviours/src/routine_behaviours/robot_routine.py
@@ -122,11 +122,11 @@ class RobotRoutine(object):
         """
         Add a task to be executed after the routine ends. These tasks cannot involve movement and therefore must either have an empty start_node_id or be performed at the charging station.
         """
-        if task.start_node_id == charging_point:
-            task.start_node_id = ''
+        if task.start_node_id == '':
+            task.start_node_id = self.charging_point
 
-        if task.start_node_id != '':
-            rospy.logwarn('Rejecting task to do %s at %s as only location-free tasks are allowed at night')
+        if task.start_node_id != self.charging_point:
+            rospy.logwarn('Rejecting task to do %s at %s as only self.charging_point tasks are allowed at night')
             return 
 
         self.night_tasks.append(task)
@@ -247,6 +247,7 @@ class RobotRoutine(object):
         now = datetime.fromtimestamp(rostime_now.to_sec(), tzlocal()).time()
 
         if len(self.night_tasks) > 0 and not self.sent_night_tasks and self.battery_state is not None and self.battery_state.charging and not self.is_during_day(now):
+
             rospy.loginfo('Sending night tasks')
             self._send_night_tasks()
          
@@ -255,12 +256,16 @@ class RobotRoutine(object):
 
         now = rospy.get_rostime()
     
+        # hack to push scheduler to do them in the order they were added
+        delta = rospy.Duration(600)
+
         for task in self.night_tasks:
             night_task = deepcopy(task)
             night_task.start_after = now
             # some arbitraty time  -- 6 hours -- in the future
             night_task.end_before = now + rospy.Duration(60 * 60 * 12)
             instantiated_night_tasks.append(night_task)
+            now = now + delta
 
 
         self.add_tasks(instantiated_night_tasks)


### PR DESCRIPTION
Night tasks should now be executed in a FIFO order based on calls to `add_night_task`.

This should be used to fix https://github.com/strands-project/g4s_deployment/issues/18
